### PR TITLE
Redo run-with-restart function

### DIFF
--- a/mpas_tasks.py
+++ b/mpas_tasks.py
@@ -130,7 +130,7 @@ def run_mpas(step, procs, executable):
 		os.chdir(world.base_dir)
 #}}}
 
-@step('I perform a (\d+) processor MPAS  "([^"]*)" run with restart')#{{{
+@step('I perform a (\d+) processor MPAS "([^"]*)" run with restart')#{{{
 def run_mpas_with_restart(step, procs, executable):
 
 	if ( world.run == True ):
@@ -141,105 +141,79 @@ def run_mpas_with_restart(step, procs, executable):
 
 		os.chdir(rundir)
 
-		#{{{ Setup initial namelist
-		duration = world.seconds_to_timestamp(world.dt)
-		final_time = world.seconds_to_timestamp(world.dt + 24*3600)
+		# Previous run should be setup to:
+		#  * be 2 time steps long
+		#  * have output interval set to the timestep length
+		#  * have restart interval set to the timestep length
 
+		# Now set up a run that does one time step, stops, then restarts for one more
+		# Setup the cold start for the first time step
 		namelistfile = open(world.namelist, 'r+')
 		lines = namelistfile.readlines()
-		namelistfile.seek(0)
-		namelistfile.truncate()
-
+		# first grab the config_dt as a string
 		for line in lines:
-			if line.find('config_start_time') >= 0:
-				new_line = "	config_start_time = 'file'\n"
-			elif line.find('config_run_duration') >= 0:
-				new_line = "	config_run_duration = '%s'\n"%duration
+			if line.find('config_dt') >= 0:
+				timestep_string = line.split("=")[1].strip().strip("'")
 			else:
 				new_line = line
-
 			namelistfile.write(new_line)
-
+		# now re-write the namelist file, updating run_duration to be 1 dt
+		namelistfile.seek(0)
+		namelistfile.truncate()
+		for line in lines:
+			if line.find('config_run_duration') >= 0:
+				new_line = "	config_run_duration = '%s'\n"%timestep_string
+			else:
+				new_line = line
+			namelistfile.write(new_line)
 		namelistfile.close()
 		del lines
-			#}}}
 
-		#{{{ Setup initial streams file
-		tree = ET.parse(world.streams)
-		root = tree.getroot()
-
-		# Loop over immutable streams to find restart streams.
-		for stream in root.findall('immutable_stream'):
-			type = stream.get('type')
-
-			if ( type.find("output") != -1 ):
-				stream.set('output_interval', '01')
-
-		# Loop over mutable streams to find restart and output streams
-		for stream in root.findall('stream'):
-			type = stream.get('type')
-			name = stream.get('name')
-
-			if ( type.find("output") != -1 ):
-				stream.set('output_interval', '01')
-
-			if ( name.find("output") != -1 ):
-				stream.set('filename_template', 'output.nc')
-
-		tree.write(world.streams)
-		del tree
-		del root
-		#}}}
-
-		command = "mpirun"
-		arg1 = "-n"
-		arg2 = "%s"%procs
-		arg3 = "./%s"%executable
+		# Perform the cold start to get half way through the standard run
 		try:
-			subprocess.check_call([command, arg1, arg2, arg3], stdout=world.dev_null, stderr=world.dev_null)  # check_call will throw an error if return code is not 0.
+			subprocess.check_call(["mpirun", "-n", "%s"%procs, "./%s"%executable], stdout=world.dev_null, stderr=world.dev_null)  # check_call will throw an error if return code is not 0.
 		except:
 			os.chdir(world.base_dir)  # return to base_dir before err'ing.
 			raise
+		# No need to keep/copy output, just continue on below
 
+		# Set namelist file to perform restart from last restart file (which you should have set up to land at the end of the run)
 		namelistfile = open(world.namelist, 'r+')
 		lines = namelistfile.readlines()
 		namelistfile.seek(0)
 		namelistfile.truncate()
-
 		for line in lines:
 			if line.find('config_do_restart') >= 0:
 				new_line = "	config_do_restart = .true.\n"
+			elif line.find('config_start_time') >= 0:
+				new_line = "	config_start_time = 'file'\n"
+			elif line.find('config_run_duration') >= 0:
+				new_line = "	config_run_duration = '%s'\n"%timestep_string  # Already set above, but setting again for clarity
 			else:
 				new_line = line
-
 			namelistfile.write(new_line)
-
-		namelistfile.write("mv output.nc %sprocs.restarted.output.nc"%(procs))
 		namelistfile.close()
 		del lines
 
-		command = "mpirun"
-		arg1 = "-n"
-		arg2 = "%s"%procs
-		arg3 = "./%s"%executable
+		# Run the restarted run to get to the end of the standard run
 		try:
-			subprocess.check_call([command, arg1, arg2, arg3], stdout=world.dev_null, stderr=world.dev_null)
+			subprocess.check_call(["mpirun", "-n", "%s"%procs, "./%s"%executable], stdout=world.dev_null, stderr=world.dev_null)
 		except:
 			os.chdir(world.base_dir)  # return to base_dir before err'ing.
 			raise
 
-		command = "mv"
-		arg1 = "output.nc"
-		arg2 = "%sprocs.restarted.output.nc"%procs
+		# Keep a copy of the completed restart run
 		try:
-			subprocess.check_call([command, arg1, arg2], stdout=world.dev_null, stderr=world.dev_null)
+			restart_output_file = "%sprocs.restarted.output.nc"%procs
+			subprocess.check_call(["mv", "output.nc", restart_output_file], stdout=world.dev_null, stderr=world.dev_null)
 		except:
 			os.chdir(world.base_dir)  # return to base_dir before err'ing.
 			raise
 
+		# Augment the world metadata with this run
 		if world.num_runs == 0:
 			world.num_runs = 1
-			world.run1 = "%s/%s"%(rundir,arg2)
+			world.run1 = "%s/%s"%(rundir,restart_output_file)
 			world.run1dir = rundir
 			try:
 				del world.rms_values
@@ -248,7 +222,7 @@ def run_mpas_with_restart(step, procs, executable):
 				world.rms_values = defaultdict(list)
 		elif world.num_runs == 1:
 			world.num_runs = 2
-			world.run2 = "%s/%s"%(rundir,arg2)
+			world.run2 = "%s/%s"%(rundir,restart_output_file)
 			world.run2dir = rundir
 		os.chdir(world.base_dir)
 #}}}

--- a/mpas_tasks.py
+++ b/mpas_tasks.py
@@ -306,6 +306,7 @@ def modify_namelist(step, testtype, groupOwningOption, optionToChange, valueToSe
 
 	with open(nl_file, 'w') as f:
 		f.write(namelist.dump())
+                f.write('\n')
 #}}}
 
 @step('I remove all streams from the "([^"]*)" stream file')#{{{

--- a/mpas_tasks.py
+++ b/mpas_tasks.py
@@ -166,6 +166,7 @@ def run_mpas_with_restart(step, procs, executable):
 			else:
 				new_line = line
 			namelistfile.write(new_line)
+                namelistfile.write('\n')
 		namelistfile.close()
 		del lines
 
@@ -192,6 +193,7 @@ def run_mpas_with_restart(step, procs, executable):
 			else:
 				new_line = line
 			namelistfile.write(new_line)
+                namelistfile.write('\n')
 		namelistfile.close()
 		del lines
 

--- a/terrain.py
+++ b/terrain.py
@@ -21,6 +21,7 @@ def check_environment():
 	world.dev_null = open(os.devnull, "w")
 	#world.dev_null = None # Turns on printing of messages from subprocess
 	world.feature_count = 0
+	world.namelist_ingested = False
 #}}}
 
 @before.each_feature#{{{


### PR DESCRIPTION
It appears the run with restart function was never being called because
there was a stray space and lettuce was matching steps that called for
it to the standard run function.  After fixing the stray space, I also
found a number of issues with how the restart function was operating.

I have largely rewritten it.  It now assumes that the previous run was
set up to:
- be 2 time steps long
- have output interval set to the timestep length
- have restart interval set to the timestep length

Then the function does a cold start that runs for one time step, then a
restart that runs for one time step more.

This could of course be generalized, but this seems like minimally
useful way to do a restart test.
